### PR TITLE
[PATCH] Fix situation where base instance lives on domain subpath 

### DIFF
--- a/directus_sdk_py/main.py
+++ b/directus_sdk_py/main.py
@@ -140,7 +140,7 @@ class DirectusClient:
     
     def clean_url(self, domain: str, path: str) -> str:
         """
-        Clean the URL by removing any leading slash.
+        Clean the URL by removing any leading or trailing slashes.
 
         Args:
             path (str): The URL path.
@@ -148,9 +148,16 @@ class DirectusClient:
         Returns:
             str: The cleaned URL path.
         """
-        clean_path = urljoin(domain, path)
-        clean_path = clean_path.replace("//", "/") if not clean_path.startswith("http://") and not clean_path.startswith("https://") and not clean_path.startswith("//") else clean_path
-        return clean_path
+        
+        # Strip slashes
+        path = path.strip('/')
+        
+        # Add subpath
+        if self.subpath is not None:
+            path = f"{self.subpath}/{path}"
+        
+        # Join to domain
+        return urljoin(domain, path)
         
     
     def get(self, path, output_type: str = "json", **kwargs):

--- a/directus_sdk_py/main.py
+++ b/directus_sdk_py/main.py
@@ -179,7 +179,7 @@ class DirectusClient:
             verify=self.verify,
             **kwargs
         )
-            raise HTTPError(_json['errors'])
+            raise HTTPError(data.json()['errors'])
         if output_type == 'csv':
             return data.text
 

--- a/directus_sdk_py/main.py
+++ b/directus_sdk_py/main.py
@@ -31,7 +31,7 @@ class DirectusClient:
         # Store path component of base url if provided
         _url = urlparse(url)
         self.url = f"{_url.scheme}://{_url.netloc}"
-        self.subpath = _url.path if _url.path != '/' else None
+        self.subpath = _url.path.strip('/') if _url.path != '/' else None
         
         if token is not None:
             self.static_token = token

--- a/directus_sdk_py/main.py
+++ b/directus_sdk_py/main.py
@@ -1,7 +1,7 @@
 import sys
 
 import requests
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 import urllib3
 from urllib3.exceptions import InsecureRequestWarning
 from typing import Dict, List, Union, Optional, Any
@@ -28,7 +28,11 @@ class DirectusClient:
         if not self.verify:
             urllib3.disable_warnings(category=InsecureRequestWarning)
         
-        self.url = url
+        # Store path component of base url if provided
+        _url = urlparse(url)
+        self.url = f"{_url.scheme}://{_url.netloc}"
+        self.subpath = _url.path if _url.path != '/' else None
+        
         if token is not None:
             self.static_token = token
             self.temporary_token = None

--- a/directus_sdk_py/main.py
+++ b/directus_sdk_py/main.py
@@ -44,7 +44,9 @@ class DirectusClient:
             self.static_token = None
             self.temporary_token = None
             
-
+    @property
+    def token_header(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.get_token()}"}
 
     def login(self, email: str = None, password: str = None) -> tuple:
         """
@@ -92,7 +94,7 @@ class DirectusClient:
             refresh_token = self.refresh_token
         requests.post(
             f"{self.url}/auth/logout",
-            headers={"Authorization": f"Bearer {self.get_token()}"},
+            headers=self.token_header,
             json={"refresh_token": refresh_token},
             verify=self.verify
         )
@@ -173,7 +175,7 @@ class DirectusClient:
         """
         data = requests.get(
             self.clean_url(self.url, path),
-            headers={"Authorization": f"Bearer {self.get_token()}"},
+            headers=self.token_header,
             verify=self.verify,
             **kwargs
         )
@@ -196,7 +198,7 @@ class DirectusClient:
         """
         response = requests.post(
             self.clean_url(self.url, path),
-            headers={"Authorization": f"Bearer {self.get_token()}"},
+            headers=self.token_header,
             verify=self.verify,
             **kwargs
         )
@@ -217,7 +219,7 @@ class DirectusClient:
         Returns:
             dict: The response data.
         """
-        headers = {"Authorization": f"Bearer {self.get_token()}"}
+        headers = self.token_header
         response = requests.request("SEARCH", self.clean_url(self.url, path), headers=headers, json=query, verify=self.verify,
                                     **kwargs)
        
@@ -237,7 +239,7 @@ class DirectusClient:
         """
         response = requests.delete(
             self.clean_url(self.url, path),
-            headers={"Authorization": f"Bearer {self.get_token()}"},
+            headers=self.token_header,
             verify=self.verify,
             **kwargs
         )
@@ -257,7 +259,7 @@ class DirectusClient:
         """
         response = requests.patch(
             self.clean_url(self.url, path),
-            headers={"Authorization": f"Bearer {self.get_token()}"},
+            headers=self.token_header,
             verify=self.verify,
             **kwargs
         )
@@ -351,7 +353,7 @@ class DirectusClient:
             str or bytes: The file content.
         """
         url = f"{self.url}/files/{file_id}"
-        headers = {"Authorization": f"Bearer {self.get_token()}"}
+        headers = self.token_header
         response = requests.get(url, headers=headers, verify=self.verify, **kwargs)
         if response.status_code != 200:
             raise HTTPError(response.text)
@@ -365,7 +367,7 @@ class DirectusClient:
             file_path (str): The path to save the file on your computer / server.
         """
         url = f"{self.url}/assets/{file_id}?download="
-        headers = {"Authorization": f"Bearer {self.get_token()}"}
+        headers = self.token_header
         response = requests.get(url, headers=headers)
     
         
@@ -405,7 +407,7 @@ class DirectusClient:
             display["transforms"] = json.dumps(transform)
 
         url = f"{self.url}/assets/{file_id}?download="
-        headers = {"Authorization": f"Bearer {self.get_token()}"}
+        headers = self.token_header
         response = requests.get(url, headers=headers, params=display, verify=self.verify)
         if response.status_code != 200:
             raise HTTPError(response.text)
@@ -474,7 +476,7 @@ class DirectusClient:
             dict: The uploaded file data.
         """
         url = f"{self.url}/files"
-        headers = {"Authorization": f"Bearer {self.get_token()}"}
+        headers = self.token_header
         with open(file_path, 'rb') as file:
             files = {'file': file}
     

--- a/directus_sdk_py/main.py
+++ b/directus_sdk_py/main.py
@@ -1,12 +1,10 @@
-import sys
-
 import requests
 from requests import HTTPError
 from urllib.parse import urljoin, urlparse
 import urllib3
 from urllib3.exceptions import InsecureRequestWarning
 from typing import Dict, List, Union, Optional, Any
-import os, json
+import json
 from dataclasses import dataclass
 
 import sqlparse


### PR DESCRIPTION
Resolves issue #4 by storing the `url` path and adding it back to any paths passed to `clean_url`

```python

>>> client = DirectusClient('https://my.domain.com/X/')
>>> client.subpath
'X' # strip all leading and trailing slashes
>>> client.url
'https://my.domain.com'

>>> client.clean_url(client.url, '/articles/1')
'https://my.domain.com/X/articles/1'
```